### PR TITLE
Rewrite updates

### DIFF
--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -1258,7 +1258,7 @@ function sf_to_block(sf::AbstractStockAndFlowF)
     dyvars = Vector{Tuple{Symbol, Expr}}([(vname, make_v_expr_nonrecursive(sf, i)) for (i, vname) ∈ enumerate(vnames(sf))])
     flows = [(sname(sf, outstock(sf,i)), :($fname($(vname(sf, fv(sf, i))))), (sname(sf, instock(sf, i)))) for (i, fname) ∈ enumerate(fnames(sf))]
     newsums = [(s1, isempty(vec) ? [] : vec) for (s1, vec) ∈ sums]
-    newflows = [((isempty(inflow) ? [:F_NONE] : inflow[1]), flow, (isempty(out) ? [:F_NONE] : out[1])) for (inflow, flow, out) ∈ flows]
+    newflows = [((isempty(inflow) ? :F_NONE : inflow[1]), flow, (isempty(out) ? :F_NONE : out[1])) for (inflow, flow, out) ∈ flows]
     s = StockAndFlowBlock(stocks, params, dyvars, newflows, newsums)
     return s;
 end

--- a/src/syntax/Rewrite.jl
+++ b/src/syntax/Rewrite.jl
@@ -454,7 +454,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
       QuoteNode(:redefs) => begin
         current_phase = redef -> begin
           @match redef begin
-            Expr(:(:=), src, tgt) => begin
+            Expr(:(=), src, tgt) => begin
               
 
               src_type = name_dict[src][1]
@@ -521,7 +521,7 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
 
 
 
-      QuoteNode(:swaps) => begin 
+      QuoteNode(:dyvar_swaps) => begin 
         current_phase = swap -> begin
           @match swap begin
             Expr(:call, :(=>), src, tgt) => begin

--- a/src/syntax/Rewrite.jl
+++ b/src/syntax/Rewrite.jl
@@ -205,7 +205,6 @@ function remove_from_sums!(stock_name, sf_block, L_block, L_set, name_dict)
   for sum ∈ sf_block.sums
     sum_name = sum[1]
     sum_stocks = sum[2]
-    
     if stock_name ∈ sum_stocks && sum_name ∉ L_set
         push!(L_block.sums, sum)
         push!(L_set, sum_name)
@@ -428,8 +427,6 @@ function sfrewrite(sf::K, block::Expr) where {K <: AbstractStockAndFlowF}
             if name_dict[removed][1] == :F
               index = name_dict[removed][2] 
               definition = deepcopy(sf_block.flows[index])
-              # push!(L_block.flows, definition)
-              # push!(L_set, val)
               stock1 = definition[1]
               if stock1 != :F_NONE && stock1 ∉ L_set && stock1 ∈ keys(name_dict)
                 push!(L_block.stocks, stock1)

--- a/test/syntax/Rewrite.jl
+++ b/test/syntax/Rewrite.jl
@@ -24,7 +24,7 @@ using AlgebraicRewriting
 
   @test (@rewrite empty begin
     :stocks
-    +A    
+    A    
     end) == A
 
   @test (@rewrite A begin
@@ -54,12 +54,12 @@ using AlgebraicRewriting
 
   @test (@rewrite p begin
     :stocks
-    +A
+    A
   end) == Ap
 
   @test (@rewrite A begin
     :parameters
-    +p
+    p
   end) == Ap
 
     # @test (@rewrite A begin
@@ -161,9 +161,9 @@ end
 
   @test (@rewrite Av begin
     :dynamic_variables
-    +v = B + B
+    v = B + B
     :stocks
-    +B
+    B
     :removes
     v
     A
@@ -204,7 +204,7 @@ end
     :swaps
     B => C
     :stocks
-    +C
+    C
     :removes
     B
   end) == ACvf
@@ -277,7 +277,7 @@ end
 
   sv4_rewrite1 = (@rewrite sv4 begin
     :stocks
-    +I
+    I
 
     :redefs
     v1 := S * I
@@ -438,21 +438,21 @@ end
 
 
     :parameters
-    + fcc
-    + fca
-    + fac
-    + faa
+    fcc
+    fca
+    fac
+    faa
 
     :dynamic_variables
 
-    + v_CCContacts = fcc * v_prevalencev_INC
-    + v_CAContacts = fca * v_prevalencev_INA
+    v_CCContacts = fcc * v_prevalencev_INC
+    v_CAContacts = fca * v_prevalencev_INA
     
-    + v_ACContacts = fac * v_prevalencev_INC
-    + v_AAContacts = faa * v_prevalencev_INA
+    v_ACContacts = fac * v_prevalencev_INC
+    v_AAContacts = faa * v_prevalencev_INA
     
-    + v_prevalencev_INC_post = v_CCContacts + v_CAContacts
-    + v_prevalencev_INA_post = v_ACContacts + v_AAContacts
+    v_prevalencev_INC_post = v_CCContacts + v_CAContacts
+    v_prevalencev_INA_post = v_ACContacts + v_AAContacts
 
   end
 

--- a/test/syntax/Rewrite.jl
+++ b/test/syntax/Rewrite.jl
@@ -1,3 +1,6 @@
+using Pkg
+Pkg.activate(".")
+
 using Test
 
 using StockFlow
@@ -25,28 +28,28 @@ using AlgebraicRewriting
     end) == A
 
   @test (@rewrite A begin
-    :stocks
-    -A
+    :removes
+    A
     end) == empty
 
   @test (@rewrite A begin
-    :stocks
-    -B
+    :removes
+    B
     end) == A
 
   @test (@rewrite p begin
-    :parameters
-    -p
+    :removes
+    p
   end) == empty
 
   @test (@rewrite Ap begin
-    :parameters
-    -p
+    :removes
+    p
   end) == A
 
   @test (@rewrite Ap begin
-    :stocks
-    -A
+    :removes
+    A
   end) == p
 
   @test (@rewrite p begin
@@ -61,7 +64,7 @@ using AlgebraicRewriting
 
     # @test (@rewrite A begin
     #   :stocks
-    #   -B
+    #   B
     #   end) == A
 
     # delete A, but shouldn't
@@ -70,7 +73,7 @@ using AlgebraicRewriting
 
     # @test (@rewrite A begin 
     #   :parameters
-    #   -A
+    #   A
     #   end) == A
     
 
@@ -117,52 +120,53 @@ end
   @test (@rewrite ABv begin
     :swaps
     B => A
-    :stocks
-    -B
+    :removes
+    B
   end) == AAv
 
   @test (@rewrite ABv begin
-    :stocks
-    -B
     :swaps
     B => A
+    :removes
+    B
   end) == AAv
 
   @test (@rewrite ABv begin
     :redefs
     v := A + A
-    :stocks
-    -B
+    :removes
+    B
   end) == AAv
 
   @test (@rewrite ABv begin
     :redefs
     v := +(A)
-    :stocks
-    -B
+    :removes
+    B
   end) == Av
 
   @test (@rewrite ABv begin
-    :stocks
-    -B
+    :removes
+    B
     :redefs
     v := +(A)
   end) == Av
 
   @test (@rewrite ABv begin
-    :stocks
-    -B
+    :removes
+    B
 
   end) == Av
 
 
   @test (@rewrite Av begin
     :dynamic_variables
-    -v
     +v = B + B
     :stocks
     +B
-    -A
+    :removes
+    v
+    A
   end) == BBv
 
 
@@ -201,7 +205,8 @@ end
     B => C
     :stocks
     +C
-    -B
+    :removes
+    B
   end) == ACvf
 
 
@@ -261,13 +266,13 @@ end
 
 
   @test (@rewrite sv1 begin
-    :stocks
-    -I
+    :removes
+    I
   end) == sv2
 
   @test (@rewrite sv3 begin
-    :stocks
-    -I
+    :removes
+    I
   end) == sv4
 
   sv4_rewrite1 = (@rewrite sv4 begin

--- a/test/syntax/Rewrite.jl
+++ b/test/syntax/Rewrite.jl
@@ -1,6 +1,3 @@
-using Pkg
-Pkg.activate(".")
-
 using Test
 
 using StockFlow
@@ -118,14 +115,14 @@ end
 
 
   @test (@rewrite ABv begin
-    :swaps
+    :dyvar_swaps
     B => A
     :removes
     B
   end) == AAv
 
   @test (@rewrite ABv begin
-    :swaps
+    :dyvar_swaps
     B => A
     :removes
     B
@@ -133,14 +130,14 @@ end
 
   @test (@rewrite ABv begin
     :redefs
-    v := A + A
+    v = A + A
     :removes
     B
   end) == AAv
 
   @test (@rewrite ABv begin
     :redefs
-    v := +(A)
+    v = +(A)
     :removes
     B
   end) == Av
@@ -149,7 +146,7 @@ end
     :removes
     B
     :redefs
-    v := +(A)
+    v = +(A)
   end) == Av
 
   @test (@rewrite ABv begin
@@ -201,7 +198,7 @@ end
   end
 
   @test (@rewrite ABvf begin
-    :swaps
+    :dyvar_swaps
     B => C
     :stocks
     C
@@ -280,10 +277,10 @@ end
     I
 
     :redefs
-    v1 := S * I
-    v2 := R * I
-    N := [S, I, R]
-    NI := [I]
+    v1 = S * I
+    v2 = R * I
+    N = [S, I, R]
+    NI = [I]
   end)
 
   @test is_natural(homomorphism(sv4_rewrite1, sv3)) && is_natural(homomorphism(sv3, sv4_rewrite1))
@@ -433,8 +430,8 @@ end
   aged_sir_rewritten = @rewrite aged_sir begin
 
     :redefs
-    v_meanInfectiousContactsPerSv_cINC := cc_C * v_prevalencev_INC_post
-    v_meanInfectiousContactsPerSv_cINA := cc_A * v_prevalencev_INA_post
+    v_meanInfectiousContactsPerSv_cINC = cc_C * v_prevalencev_INC_post
+    v_meanInfectiousContactsPerSv_cINA = cc_A * v_prevalencev_INA_post
 
 
     :parameters

--- a/test/syntax/Rewrite.jl
+++ b/test/syntax/Rewrite.jl
@@ -1,3 +1,6 @@
+using Pkg;
+Pkg.activate(".")
+
 using Test
 
 using StockFlow
@@ -58,20 +61,6 @@ using AlgebraicRewriting
     :parameters
     p
   end) == Ap
-
-    # @test (@rewrite A begin
-    #   :stocks
-    #   B
-    #   end) == A
-
-    # delete A, but shouldn't
-    # We might want to just add a :removes section and if you put it under
-    # a :parameters or :stocks header it's just added.
-
-    # @test (@rewrite A begin 
-    #   :parameters
-    #   A
-    #   end) == A
     
 
 end
@@ -79,7 +68,6 @@ end
 
 @testset "Basic dynamic variable manipulation" begin
   # You should never swap both variables in a dynamic variable in one rewrite.
-
 
   ABv = @stock_and_flow begin
     :stocks
@@ -285,6 +273,20 @@ end
 
   @test is_natural(homomorphism(sv4_rewrite1, sv3)) && is_natural(homomorphism(sv3, sv4_rewrite1))
 
+
+
+  @test (@rewrite (@stock_and_flow begin
+    :stocks
+    A
+    :sums
+    N = [A]
+  end) begin
+    :removes
+    A
+  end) == (@stock_and_flow begin 
+    :sums
+    N = []
+  end)
 
 
 end


### PR DESCRIPTION
Updated rewrite syntax
- Use = instead of := in redefs
- When deleting, use the :removes header, and don't prepend a -
- When adding, use the header for the type you're adding (eg :stocks, :flows) and don't prepend a +
- :swaps is now called :dyvar_swaps